### PR TITLE
implement RGB in addition to existing GRB format

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ separately.
 
 ```blocks
 // Create a NeoPixel driver - specify the pin, number of LEDs, and the type of 
-// the NeoPixel srip, either standard RGB or RGB+White.
+// the NeoPixel srip, either standard RGB (with GRB or RGB format) or RGB+White.
 let strip = neopixel.create(DigitalPin.P0, 24, NeoPixelMode.RGB)
 
 // set pixel colors


### PR DESCRIPTION
Dear developers,

many thanks for the work on pxt for the BBC microbit in general and the Neopixel lib in particular. They are great tools to teach children about computers and programming.

I was building some Christmas decoration with a child. For this I wanted to use some through hole Neopixels I had lying around (https://www.adafruit.com/products/1734). Unluckily these use RGB encoding instead of GRB encoding. While switching the red and green values is easy enough, for young children there is enough other stuff to bother about. To avoid confusion, I extended the lib to support the RGB format as well as the much more common GRB format. 

In case, you are interested, I make my code available via this pull request. Many thanks again for making Neopixels so easily usable. You enabled me to do this fun project with an 12 year old who had never programmed before.

Thomas Tuerk