### PR TITLE
Adding translation of "Black" in Japanese.

### DIFF
--- a/_locales/ja/neopixel-strings.json
+++ b/_locales/ja/neopixel-strings.json
@@ -11,6 +11,7 @@
   "NeoPixelColors.Violet|block": "すみれ",
   "NeoPixelColors.Purple|block": "紫",
   "NeoPixelColors.White|block": "白",
+  "NeoPixelColors.Black|block": "黒",
   "neopixel.Strip.showColor|block": "%strip|を%rgb=neopixel_colors|色に点灯する",
   "neopixel.Strip.showRainbow|block": "%strip|をレインボーパターン（色相%startHue|から%endHue|）に点灯する",
   "neopixel.Strip.showBarGraph|block": "%strip|棒グラフで点灯する 値%value|最大値%high",


### PR DESCRIPTION
"black" in the color list was not translated.
![makecode](https://github.com/microsoft/pxt-neopixel/assets/42832770/70dfdb44-afdf-42b1-9245-49be5154e1c8)
